### PR TITLE
Add advisor selection to profile page with API integration

### DIFF
--- a/src/constants/Api.ts
+++ b/src/constants/Api.ts
@@ -9,6 +9,7 @@ export enum Api {
   CURRENT_YEAR_SEMESTER = '/setting/current-year-semester',
   // STUDENT = '/student',
   STUDENT_PROFILE = '/student',
+  ADVISOR = '/advisor',
 
   // Auth
   SIGNIN = '/auth/signin',

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -8,6 +8,7 @@ const Profile = () => {
     watch,
     errors,
     name,
+    advisors,
     profile,
     onSubmit,
     handleSubmit,
@@ -62,9 +63,11 @@ const Profile = () => {
                 valueAsNumber: true,
               })}
             >
-              <option value={1}>อาจารย์ A</option>
-              <option value={2}>อาจารย์ B</option>
-              <option value={3}>อาจารย์ C</option>
+              {advisors.map((advisor) => (
+                <option key={advisor.id} value={advisor.id}>
+                  {advisor.name}
+                </option>
+              ))}
             </select>
             {errors.advisorId && (
               <div className="text-red-500 text-sm">

--- a/src/pages/Profile/useProfileController.tsx
+++ b/src/pages/Profile/useProfileController.tsx
@@ -22,6 +22,11 @@ export interface EditStudentProfile {
   bookBank: File[];
 }
 
+export interface Advisor {
+  id: number;
+  name: string;
+}
+
 const useProfileController = () => {
   const { roles } = useAuth();
   const httpClient = useHttpClient();
@@ -34,12 +39,16 @@ const useProfileController = () => {
     formState: { errors, dirtyFields, touchedFields },
   } = useForm<EditStudentProfile>();
   const [name, setName] = useState<string>('');
+  const [advisors, setAdvisors] = useState<Advisor[]>([]);
   const [profile, setProfile] = useState<StudentProfile | null>(null);
   const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
   const [isSubmitModalOpen, setIsSubmitModalOpen] = useState(false);
 
   useEffect(() => {
     if (roles.includes(Role.STUDENT)) {
+      httpClient.get<Advisor[]>(Api.ADVISOR).then((data) => {
+        setAdvisors(data);
+      });
       httpClient.get<StudentProfile>(Api.STUDENT_PROFILE).then((data) => {
         setName(data.firstName + ' ' + data.lastName);
         setProfile(data);
@@ -111,6 +120,7 @@ const useProfileController = () => {
     onSubmit,
     navigateBack,
     name,
+    advisors,
     profile,
     isCancelModalOpen,
     setIsCancelModalOpen,


### PR DESCRIPTION
Integrate advisor selection into the profile page, allowing users to choose from a list of advisors fetched from the API. This enhances the user experience by providing dynamic options instead of static ones.